### PR TITLE
Adding JoblibPool and fixing callback bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - pip install pytest
   - pip install cython
   - pip install mpi4py
+  - pip install joblib
   - pip install -vvv .
 
 before_script:

--- a/schwimmbad/jl.py
+++ b/schwimmbad/jl.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+try:
+    from joblib import Parallel, delayed
+except ImportError:
+    Parallel = None
+
+from .pool import BasePool
+
+__all__ = ["JoblibPool"]
+
+
+class JoblibPool(BasePool):
+
+    def __init__(self, *args, **kwargs):
+        if Parallel is None:
+            raise ImportError("joblib is required to use the JoblibPool")
+        self.args = args
+        self.kwargs = kwargs
+        self.size = 0
+        self.rank = 0
+
+    @staticmethod
+    def enabled():
+        return Parallel is not None
+
+    def map(self, func, iterable, callback=None):
+        dfunc = delayed(func)
+        res = Parallel(*(self.args), **(self.kwargs))(
+            dfunc(a) for a in iterable
+        )
+        if callback is not None:
+            res = list(res)
+            list(map(callback, res))
+        return res

--- a/schwimmbad/serial.py
+++ b/schwimmbad/serial.py
@@ -30,7 +30,8 @@ class SerialPool(BasePool):
             function returns but before the results are returned.
 
         """
-        results = list(map(func, iterable))
+        results = map(func, iterable)
         if callback is not None:
-            map(callback, results)
+            results = list(results)
+            list(map(callback, results))
         return results

--- a/schwimmbad/tests/test_pools.py
+++ b/schwimmbad/tests/test_pools.py
@@ -6,6 +6,7 @@ import random
 # Project
 from ..serial import SerialPool
 from ..multiprocessing import MultiPool
+from ..jl import JoblibPool
 try:
     from mpi4py import MPI
 except ImportError:
@@ -49,9 +50,15 @@ class PoolTestBase(object):
         pool = self._make_pool()
 
         for tasks in self.all_tasks:
-            results = pool.map(_function, tasks, callback=callback)
+
+            mylist = []
+            def _callback(o):
+                mylist.append(o)
+
+            results = pool.map(_function, tasks, callback=_callback)
             for r1,r2 in zip(results, [_function(x) for x in tasks]):
                 assert isclose(r1, r2)
+            assert len(mylist) == len(tasks)
 
         pool.close()
 
@@ -62,3 +69,7 @@ class TestSerialPool(PoolTestBase):
 class TestMultiPool(PoolTestBase):
     def setup(self):
         self.PoolClass = MultiPool
+
+class TestJoblibPool(PoolTestBase):
+    def setup(self):
+        self.PoolClass = JoblibPool

--- a/schwimmbad/tests/test_pools.py
+++ b/schwimmbad/tests/test_pools.py
@@ -22,8 +22,6 @@ def _function(x):
     time.sleep(random.random()*4E-4 + 1E-4)
     return 42.01
 
-def callback(x):
-    assert isclose(x, 42.01)
 
 class PoolTestBase(object):
 
@@ -52,8 +50,9 @@ class PoolTestBase(object):
         for tasks in self.all_tasks:
 
             mylist = []
-            def _callback(o):
-                mylist.append(o)
+            def _callback(x):
+                assert isclose(x, 42.01)
+                mylist.append(x)
 
             results = pool.map(_function, tasks, callback=_callback)
             for r1,r2 in zip(results, [_function(x) for x in tasks]):


### PR DESCRIPTION
In this pull request I'm adding two things - bad practice, I know.

1. Added a pool that uses [Joblib](https://pythonhosted.org/joblib/) (the backend for scikit learn) for parallelization. For Cython and numpy code, this can have better memory usage and less overhead than multiprocessing.

2. I also fixed a bug where the SerialPool wasn't actually calling the callback function. I modified the callback test to check for this.

I was not entirely sure about the desired behavior – should a pool.map method return a generator or a list. I think generator is probably better if we can but it's your call!