### PR TITLE
Making map always return generators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - pip install pytest
   - pip install cython
   - pip install mpi4py
+  - pip install joblib
   - pip install -vvv .
 
 before_script:

--- a/schwimmbad/jl.py
+++ b/schwimmbad/jl.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import division, print_function
+
+try:
+    from joblib import Parallel, delayed
+except ImportError:
+    Parallel = None
+
+from .pool import BasePool
+
+__all__ = ["JoblibPool"]
+
+
+class JoblibPool(BasePool):
+
+    def __init__(self, *args, **kwargs):
+        if Parallel is None:
+            raise ImportError("joblib is required to use the JoblibPool")
+        self.args = args
+        self.kwargs = kwargs
+        self.size = 0
+        self.rank = 0
+
+    @staticmethod
+    def enabled():
+        return Parallel is not None
+
+    def map(self, func, iterable, callback=None):
+        dfunc = delayed(func)
+        res = Parallel(*(self.args), **(self.kwargs))(
+            dfunc(a) for a in iterable
+        )
+        if callback is not None:
+            res = list(res)
+            list(map(callback, res))
+        return res

--- a/schwimmbad/jl.py
+++ b/schwimmbad/jl.py
@@ -31,7 +31,4 @@ class JoblibPool(BasePool):
         res = Parallel(*(self.args), **(self.kwargs))(
             dfunc(a) for a in iterable
         )
-        if callback is not None:
-            res = list(res)
-            list(map(callback, res))
-        return res
+        return self._call_callback(callback, res)

--- a/schwimmbad/pool.py
+++ b/schwimmbad/pool.py
@@ -39,3 +39,10 @@ class BasePool(object):
 
     def __exit__(self, *args):
         self.close()
+
+    def _call_callback(self, callback, generator):
+        if callback is None:
+            return generator
+        for element in generator:
+            callback(element)
+            yield element

--- a/schwimmbad/serial.py
+++ b/schwimmbad/serial.py
@@ -30,8 +30,4 @@ class SerialPool(BasePool):
             function returns but before the results are returned.
 
         """
-        results = map(func, iterable)
-        if callback is not None:
-            results = list(results)
-            list(map(callback, results))
-        return results
+        return self._call_callback(callback, map(func, iterable))

--- a/schwimmbad/serial.py
+++ b/schwimmbad/serial.py
@@ -30,7 +30,8 @@ class SerialPool(BasePool):
             function returns but before the results are returned.
 
         """
-        results = list(map(func, iterable))
+        results = map(func, iterable)
         if callback is not None:
-            map(callback, results)
+            results = list(results)
+            list(map(callback, results))
         return results

--- a/schwimmbad/tests/test_pools.py
+++ b/schwimmbad/tests/test_pools.py
@@ -6,6 +6,7 @@ import random
 # Project
 from ..serial import SerialPool
 from ..multiprocessing import MultiPool
+from ..jl import JoblibPool
 try:
     from mpi4py import MPI
 except ImportError:
@@ -49,9 +50,15 @@ class PoolTestBase(object):
         pool = self._make_pool()
 
         for tasks in self.all_tasks:
-            results = pool.map(_function, tasks, callback=callback)
+
+            mylist = []
+            def _callback(o):
+                mylist.append(o)
+
+            results = pool.map(_function, tasks, callback=_callback)
             for r1,r2 in zip(results, [_function(x) for x in tasks]):
                 assert isclose(r1, r2)
+            assert len(mylist) == len(tasks)
 
         pool.close()
 
@@ -62,3 +69,7 @@ class TestSerialPool(PoolTestBase):
 class TestMultiPool(PoolTestBase):
     def setup(self):
         self.PoolClass = MultiPool
+
+class TestJoblibPool(PoolTestBase):
+    def setup(self):
+        self.PoolClass = JoblibPool

--- a/schwimmbad/tests/test_pools.py
+++ b/schwimmbad/tests/test_pools.py
@@ -22,8 +22,6 @@ def _function(x):
     time.sleep(random.random()*4E-4 + 1E-4)
     return 42.01
 
-def callback(x):
-    assert isclose(x, 42.01)
 
 class PoolTestBase(object):
 
@@ -52,8 +50,9 @@ class PoolTestBase(object):
         for tasks in self.all_tasks:
 
             mylist = []
-            def _callback(o):
-                mylist.append(o)
+            def _callback(x):
+                assert isclose(x, 42.01)
+                mylist.append(x)
 
             results = pool.map(_function, tasks, callback=_callback)
             for r1,r2 in zip(results, [_function(x) for x in tasks]):


### PR DESCRIPTION
You may or may not actually want this but here's a way that the pools could always return generators instead of lists. This should probably only be diffed after merging #2.