### PR TITLE
Adding callback option to MPIPool.wait()

### DIFF
--- a/schwimmbad/__init__.py
+++ b/schwimmbad/__init__.py
@@ -3,6 +3,7 @@
 Contributions by:
 - Peter K. G. Williams
 - Júlio Hoffimann Mendes
+- Dan Foreman-Mackey
 
 Implementations of four different types of processing pools:
 
@@ -21,6 +22,7 @@ _VERBOSE = 5
 from .multiprocessing import MultiPool
 from .serial import SerialPool
 from .mpi import MPIPool
+from .jl import JoblibPool
 
 def choose_pool(mpi=False, processes=1, **kwargs):
     """

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -57,7 +57,7 @@ class MPIPool(BasePool):
                 return True
         return False
 
-    def wait(self):
+    def wait(self, callback=None):
         """
         Make the workers listen to the master.
         """
@@ -85,6 +85,9 @@ class MPIPool(BasePool):
                     .format(worker, result, status.tag))
 
             self.comm.ssend(result, self.master, status.tag)
+
+        if callback is not None:
+            callback()
 
     def map(self, func, iterable, callback=None):
         """

--- a/scripts/test_mpi.py
+++ b/scripts/test_mpi.py
@@ -1,5 +1,5 @@
 """
-I couldn't figure out how to get py.test and MPI to play nice together, 
+I couldn't figure out how to get py.test and MPI to play nice together,
 so this is a script that tests the MPIPool
 """
 
@@ -18,12 +18,10 @@ if MPI is not None and MPI.COMM_WORLD.Get_size() > 1:
 
     pool = MPIPool()
 
-    if not pool.is_master():
-        pool.wait()
-        sys.exit(0)
-    
+    pool.wait(lambda: sys.exit(0))
+
     all_tasks = [[random.random() for i in range(1000)]]
-    
+
     # test map alone
     for tasks in all_tasks:
         results = pool.map(_function, tasks)


### PR DESCRIPTION
This change allows you to use:

```
pool.wait(lambda: sys.exit(0))
```

instead of

```
if not pool.is_master():
    pool.wait()
    sys.exit(0)
```

although the latter will still work.

Another option would be to use a keyword argument like `exit_processes` or something since I pretty much always want to have the `sys.exit(0)` and I _always_ forget to include it.