### PR TITLE
use deferred formatting within map function

### DIFF
--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -112,8 +112,8 @@ class MPIPool(BasePool):
             if workerset and tasklist:
                 worker = workerset.pop()
                 taskid, task = tasklist.pop()
-                log.log(_VERBOSE, "Sent task {0} to worker {1} with tag {2}"
-                        .format(task[1], worker, taskid))
+                log.log(_VERBOSE, "Sent task %s to worker %s with tag %s",
+                        task[1], worker, taskid)
                 self.comm.send(task, dest=worker, tag=taskid)
 
             if tasklist:
@@ -127,8 +127,8 @@ class MPIPool(BasePool):
             result = self.comm.recv(source=MPI.ANY_SOURCE, tag=MPI.ANY_TAG, status=status)
             worker = status.source
             taskid = status.tag
-            log.log(_VERBOSE, "Master received from worker {0} with tag {1}"
-                    .format(worker, taskid))
+            log.log(_VERBOSE, "Master received from worker %s with tag %s",
+                    worker, taskid)
 
             callback(result)
 


### PR DESCRIPTION
We are testing out using your nice package as a generic pool for parameter estimation (in conjunction with kombine and pycbc). I like the interface! I've found a bit of a bottleneck in the way the logging is done within the map function, however. It seems a string is created that contains the arguments to be passed. For us this takes quite a long time, as seen in the profile graph below. 

![25a2bff9-08a0-4e3d-bb71-4290bd8df730 log 1](https://cloud.githubusercontent.com/assets/2206534/21710510/718a16de-d3e9-11e6-9151-ac820ab53ff3.png)

A simple solution is to use the logging modules deferred string interpolation. It seems to go against the style of using .format everywhere, though. @adrn How does this sound to you? 