### PR TITLE
Fix failing installation in case six was not installed before

### DIFF
--- a/schwimmbad/__init__.py
+++ b/schwimmbad/__init__.py
@@ -13,19 +13,23 @@ Implementations of four different types of processing pools:
 
 """
 
-__version__ = "0.4.dev"
+import logging
+import sys
+
+import pkg_resources
+
+from .jl import JoblibPool
+from .mpi import MPIPool
+from .multiprocessing import MultiPool
+from .serial import SerialPool
+
+__version__ = pkg_resources.require(__package__)[0].version
+
 __author__ = "Adrian Price-Whelan <adrianmpw@gmail.com>"
 
-# Standard library
-import sys
-import logging
 log = logging.getLogger(__name__)
 _VERBOSE = 5
 
-from .multiprocessing import MultiPool
-from .serial import SerialPool
-from .mpi import MPIPool
-from .jl import JoblibPool
 
 def choose_pool(mpi=False, processes=1, **kwargs):
     """

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@
 # Release to pypi with:
 # python setup.py sdist upload
 
-# Standard library
-import sys
 import locale
 import os
 import subprocess
+# Standard library
+import sys
 import warnings
 
 try:
@@ -30,9 +30,9 @@ else:
         f.close()
         return r
 
-# Remove the .dev for release
-import schwimmbad
-VERSION = schwimmbad.__version__
+# Remove the .dev for release, this is the only place to change for new
+# versions:
+VERSION = "0.4.dev"
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
Running `pip install schwimmbad` imported `schwimmbad` within `setup.py` which  raised an exception in case `six` was not installed already.

This import in `setup.py` was necessary to determine the current  version. 

To fix this the version is explicitly set version in `setup.py` and then in  `__init__.py` the current version is retrieved using `pkg_resources`  module.