### PR TITLE
fix installation when six is not installed yet

### DIFF
--- a/schwimmbad/__init__.py
+++ b/schwimmbad/__init__.py
@@ -12,8 +12,9 @@ Implementations of four different types of processing pools:
     - SerialPool: A serial pool, which uses the built-in ``map`` function
 
 """
+import pkg_resources
 
-__version__ = "0.4.dev"
+__version__ = pkg_resources.require(__package__)[0].version
 __author__ = "Adrian Price-Whelan <adrianmpw@gmail.com>"
 
 # Standard library

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@
 # python setup.py sdist upload
 
 # Standard library
-import sys
 import locale
 import os
 import subprocess
+import sys
 import warnings
 
 try:
@@ -31,8 +31,7 @@ else:
         return r
 
 # Remove the .dev for release
-import schwimmbad
-VERSION = schwimmbad.__version__
+VERSION = "0.4.dev"
 
 # Indicates if this version is a release version
 RELEASE = 'dev' not in VERSION


### PR DESCRIPTION
PLEASE DELETE MY PREVIOUS PULL REQUEST WITH SAME NAME.

Version is now set in `setup.py` and not in `__init__.py`, thus `import schwimmbad` is not required in `setup.py` anymore.

Old behaviour could break, because `import schwimmbad` in `setup.py` triggered `import six` which might not be installed at this point of time.

