### PR TITLE
Add an asynchronous MPI pool based on mpi4py.futures.MPIPoolExecutor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   # - 2.7
   # - 3.5
   - 3.6
+  - 3.7
 
 os: linux
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
         - MPI=openmpi
         - TEST_CMD='py.test --cov --cov-append'
         # - MPI_TEST_CMD='coverage run -a' # if we can get coverage working...
-        - MPI_TEST_CMD='python'
         - RUN_COVERAGE=true
 
 before_install:
@@ -48,7 +47,8 @@ before_script:
   - if [[ "$MPI" == "mpich" ]]; then P=2; else P=5; fi
 
 script:
-  - mpiexec -n $P $MPI_TEST_CMD $PWD/schwimmbad/tests/test_mpi.py
+  - SCHWIMMBAD_TEST_MPI=1 mpiexec -n $P python $PWD/schwimmbad/tests/test_mpi.py
+  - SCHWIMMBAD_TEST_MPIASYNC=1 mpiexec -n $P python -m mpi4py.futures $PWD/schwimmbad/tests/test_mpi.py
   - $TEST_CMD
 
 after_success:

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -223,6 +223,24 @@ class MPIAsyncPool(MPIPoolExecutor):
         mpirun -n <ncores> python -m mpi4py.futures <script name>
     """
 
+    def __init__(self, max_workers=None, comm=None, **kwargs):
+        super().__init__(max_workers=max_workers, **kwargs)
+
+        _import_mpi()
+
+        if comm is None:
+            comm = MPI.COMM_WORLD
+        self.comm = comm
+
+        self.master = 0
+        self.rank = self.comm.Get_rank()
+        self.size = self.comm.Get_size() - 1
+
+        if self.size == 0:
+            raise ValueError("Tried to create an MPI pool, but there "
+                             "was only one MPI process available. "
+                             "Need at least two.")
+
     def starmap(self, fn, iterable, callback=None, **kwargs):
         """Return an iterator equivalent to ``itertools.starmap(...)``.
         Args:

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -2,8 +2,7 @@
 # it only when an MPI Pool is explicitly created.
 # Still make it a global to avoid messing up other things.
 MPI = None
-
-from mpi4py.futures import MPIPoolExecutor
+MPIPoolExecutor = None
 
 # Project
 from . import log, _VERBOSE
@@ -16,9 +15,14 @@ def _dummy_callback(x):
 
 def _import_mpi(quiet=False):
     global MPI
+    global MPIPoolExecutor
     try:
         import mpi4py.MPI
         MPI = mpi4py.MPI
+
+        from mpi4py.futures import MPIPoolExecutor as tmp
+        MPIPoolExecutor = tmp
+
     except ImportError:
         if not quiet:
             # Re-raise with a more user-friendly error:
@@ -200,7 +204,7 @@ def custom_starmap_helper(submit, worker, callback, iterable):
 
         if callback is not None:
             future.add_done_callback(callback)
-            
+
         futures.append(future)
 
     def result_iterator():  # pylint: disable=missing-docstring

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -220,26 +220,31 @@ def custom_starmap_helper(submit, worker, callback, iterable):
     return result_iterator()
 
 
-class MPIAsyncPool(MPIPoolExecutor):
-    """Note: run with something like
+if MPI is not None:
+    class MPIAsyncPool(MPIPoolExecutor):
+        """Note: run with something like
 
-        mpirun -n <ncores> python -m mpi4py.futures <script name>
-    """
-
-    def starmap(self, fn, iterable, callback=None, **kwargs):
-        """Return an iterator equivalent to ``itertools.starmap(...)``.
-        Args:
-            fn: A callable that will take positional argument from iterable.
-            iterable: An iterable yielding ``args`` tuples to be used as
-                positional arguments to call ``fn(*args)``.
-            callback: A callable that is called on the result of each fn call.
-        Keyword Args:
-        Returns:
-            An iterator equivalent to ``itertools.starmap(fn, iterable)``
-            but the calls may be evaluated out-of-order.
-        Raises:
-            TimeoutError: If the entire result iterator could not be generated
-                before the given timeout.
-            Exception: If ``fn(*args)`` raises for any values.
+            mpirun -n <ncores> python -m mpi4py.futures <script name>
         """
-        return custom_starmap_helper(self.submit, fn, callback, iterable)
+
+        def starmap(self, fn, iterable, callback=None, **kwargs):
+            """Return an iterator equivalent to ``itertools.starmap(...)``.
+            Args:
+                fn: A callable that will take positional argument from iterable.
+                iterable: An iterable yielding ``args`` tuples to be used as
+                    positional arguments to call ``fn(*args)``.
+                callback: A callable that is called on the result of each fn call.
+            Keyword Args:
+            Returns:
+                An iterator equivalent to ``itertools.starmap(fn, iterable)``
+                but the calls may be evaluated out-of-order.
+            Raises:
+                TimeoutError: If the entire result iterator could not be generated
+                    before the given timeout.
+                Exception: If ``fn(*args)`` raises for any values.
+            """
+            return custom_starmap_helper(self.submit, fn, callback, iterable)
+
+else:
+    class MPIAsyncPool:
+        pass

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -214,6 +214,10 @@ def custom_starmap_helper(submit, worker, callback, iterable):
 
 
 class MPIAsyncPool(MPIPoolExecutor):
+    """Note: run with something like
+
+        mpirun -n <ncores> python -m mpi4py.futures <script name>
+    """
 
     def starmap(self, fn, iterable, callback=None, **kwargs):
         """Return an iterator equivalent to ``itertools.starmap(...)``.

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -8,7 +8,7 @@ MPIPoolExecutor = None
 from . import log, _VERBOSE
 from .pool import BasePool
 
-__all__ = ['MPIPool']
+__all__ = ['MPIPool', 'MPIAsyncPool']
 
 def _dummy_callback(x):
     pass

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -218,9 +218,36 @@ def custom_starmap_helper(submit, worker, callback, iterable):
 
 
 class MPIAsyncPool(MPIPoolExecutor):
-    """Note: run with something like
+    """A processing pool that asynchronously distributes tasks using MPI.
+
+    With this pool class, the master process distributes tasks to worker
+    processes using an MPI communicator. This pool therefore supports parallel
+    processing on large compute clusters and in environments with multiple
+    nodes or computers that each have many processor cores.
+
+    This class subclasses ``mpi4py.futures.MPIPoolExecutor`` but adds support
+    for specifying a callback function that is called from the rank 0 process
+    as soon as the worker function completes.
+
+    Note that, to use this pool with ``mpiexec`` or ``mpirun``, you must execute
+    your script with::
 
         mpirun -n <ncores> python -m mpi4py.futures <script name>
+
+    See the `mpi4py.futures documentation
+    <https://mpi4py.readthedocs.io/en/stable/mpi4py.futures.html>`_ for more
+    information.
+
+    Parameters
+    ----------
+    max_workers : int, optional
+        The maximum number of worker processes to spawn.
+    comm : :class:`mpi4py.MPI.Comm`, optional
+        An MPI communicator to distribute tasks with. If ``None``, this uses
+        ``MPI.COMM_WORLD`` by default.
+    **kwargs
+        All other keyword arguments are passed to the
+        ``mpi4py.futures.MPIPoolExecutor`` initializer.
     """
 
     def __init__(self, max_workers=None, comm=None, **kwargs):
@@ -241,23 +268,67 @@ class MPIAsyncPool(MPIPoolExecutor):
                              "was only one MPI process available. "
                              "Need at least two.")
 
-    def starmap(self, fn, iterable, callback=None, **kwargs):
-        """Return an iterator equivalent to ``itertools.starmap(...)``.
-        Args:
-            fn: A callable that will take positional argument from iterable.
-            iterable: An iterable yielding ``args`` tuples to be used as
-                positional arguments to call ``fn(*args)``.
-            callback: A callable that is called on the result of each fn call.
-        Keyword Args:
-        Returns:
-            An iterator equivalent to ``itertools.starmap(fn, iterable)``
-            but the calls may be evaluated out-of-order.
-        Raises:
-            TimeoutError: If the entire result iterator could not be generated
-                before the given timeout.
-            Exception: If ``fn(*args)`` raises for any values.
+    def starmap(self, worker, tasks, callback=None, **kwargs):
+        """The callable, ``worker``, is called on each element of the ``tasks``
+        iterable. The results are returned in the expected order (symmetric with
+        ``tasks``).
+
+        Parameters
+        ----------
+        worker : callable
+            A function or callable object that is executed on each element of
+            the specified ``tasks`` iterable. This object must be picklable
+            (i.e. it can't be a function scoped within a function or a
+            ``lambda`` function). This should accept a single positional
+            argument and return a single object.
+        tasks : iterable
+            A list or iterable of tasks. Each task can be itself an iterable
+            (e.g., tuple) of values or data to pass in to the worker function.
+        callback : callable, optional
+            An optional callback function (or callable) that is called with the
+            result from each worker run and is executed on the master process.
+            This is useful for, e.g., saving results to a file, since the
+            callback is only called on the master thread.
+
+        Returns
+        -------
+        results : iterator
+            An iterator equivalent to ``itertools.starmap(fn, iterable)``.
+            The calls may be evaluated out-of-order, but the results will always
+            come back in order.
         """
-        return custom_starmap_helper(self.submit, fn, callback, iterable)
+        return custom_starmap_helper(self.submit, worker, callback, tasks)
+
+    def map(self, worker, tasks, callback=None, **kwargs):
+        """The callable, ``worker``, is called on each element of the ``tasks``
+        iterable. The results are returned in the expected order (symmetric with
+        ``tasks``).
+
+        Parameters
+        ----------
+        worker : callable
+            A function or callable object that is executed on each element of
+            the specified ``tasks`` iterable. This object must be picklable
+            (i.e. it can't be a function scoped within a function or a
+            ``lambda`` function). This should accept a single positional
+            argument and return a single object.
+        tasks : iterable
+            A list or iterable of tasks. Each task can be itself an iterable
+            (e.g., tuple) of values or data to pass in to the worker function.
+        callback : callable, optional
+            An optional callback function (or callable) that is called with the
+            result from each worker run and is executed on the master process.
+            This is useful for, e.g., saving results to a file, since the
+            callback is only called on the master thread.
+
+        Returns
+        -------
+        results : iterator
+            An iterator equivalent to ``itertools.starmap(fn, iterable)``.
+            The calls may be evaluated out-of-order, but the results will always
+            come back in order.
+        """
+        return super().map(worker, tasks, callback=callback, **kwargs)
 
     def close(self):
         self.shutdown()

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -240,3 +240,6 @@ class MPIAsyncPool(MPIPoolExecutor):
             Exception: If ``fn(*args)`` raises for any values.
         """
         return custom_starmap_helper(self.submit, fn, callback, iterable)
+
+    def close(self):
+        self.shutdown()

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -197,7 +197,10 @@ def custom_starmap_helper(submit, worker, callback, iterable):
     futures = []
     for args in iterable:
         future = submit(worker, *args)
-        future.add_done_callback(callback)
+
+        if callback is not None:
+            future.add_done_callback(callback)
+            
         futures.append(future)
 
     def result_iterator():  # pylint: disable=missing-docstring
@@ -235,7 +238,4 @@ class MPIAsyncPool(MPIPoolExecutor):
                 before the given timeout.
             Exception: If ``fn(*args)`` raises for any values.
         """
-        if callback is None:
-            callback = lambda *args, **kwargs: pass
-
         return custom_starmap_helper(self.submit, fn, callback, iterable)

--- a/schwimmbad/mpi.py
+++ b/schwimmbad/mpi.py
@@ -2,7 +2,9 @@
 # it only when an MPI Pool is explicitly created.
 # Still make it a global to avoid messing up other things.
 MPI = None
-MPIPoolExecutor = None
+
+# It seems like it's ok to import this even if not run with MPI
+from mpi4py.futures import MPIPoolExecutor
 
 # Project
 from . import log, _VERBOSE
@@ -15,14 +17,9 @@ def _dummy_callback(x):
 
 def _import_mpi(quiet=False):
     global MPI
-    global MPIPoolExecutor
     try:
         import mpi4py.MPI
         MPI = mpi4py.MPI
-
-        from mpi4py.futures import MPIPoolExecutor as tmp
-        MPIPoolExecutor = tmp
-
     except ImportError:
         if not quiet:
             # Re-raise with a more user-friendly error:
@@ -220,31 +217,26 @@ def custom_starmap_helper(submit, worker, callback, iterable):
     return result_iterator()
 
 
-if MPI is not None:
-    class MPIAsyncPool(MPIPoolExecutor):
-        """Note: run with something like
+class MPIAsyncPool(MPIPoolExecutor):
+    """Note: run with something like
 
-            mpirun -n <ncores> python -m mpi4py.futures <script name>
+        mpirun -n <ncores> python -m mpi4py.futures <script name>
+    """
+
+    def starmap(self, fn, iterable, callback=None, **kwargs):
+        """Return an iterator equivalent to ``itertools.starmap(...)``.
+        Args:
+            fn: A callable that will take positional argument from iterable.
+            iterable: An iterable yielding ``args`` tuples to be used as
+                positional arguments to call ``fn(*args)``.
+            callback: A callable that is called on the result of each fn call.
+        Keyword Args:
+        Returns:
+            An iterator equivalent to ``itertools.starmap(fn, iterable)``
+            but the calls may be evaluated out-of-order.
+        Raises:
+            TimeoutError: If the entire result iterator could not be generated
+                before the given timeout.
+            Exception: If ``fn(*args)`` raises for any values.
         """
-
-        def starmap(self, fn, iterable, callback=None, **kwargs):
-            """Return an iterator equivalent to ``itertools.starmap(...)``.
-            Args:
-                fn: A callable that will take positional argument from iterable.
-                iterable: An iterable yielding ``args`` tuples to be used as
-                    positional arguments to call ``fn(*args)``.
-                callback: A callable that is called on the result of each fn call.
-            Keyword Args:
-            Returns:
-                An iterator equivalent to ``itertools.starmap(fn, iterable)``
-                but the calls may be evaluated out-of-order.
-            Raises:
-                TimeoutError: If the entire result iterator could not be generated
-                    before the given timeout.
-                Exception: If ``fn(*args)`` raises for any values.
-            """
-            return custom_starmap_helper(self.submit, fn, callback, iterable)
-
-else:
-    class MPIAsyncPool:
-        pass
+        return custom_starmap_helper(self.submit, fn, callback, iterable)

--- a/schwimmbad/tests/test_mpi.py
+++ b/schwimmbad/tests/test_mpi.py
@@ -4,20 +4,22 @@ so this is a script that tests the MPIPool
 """
 
 # Standard library
+import os
 import random
 import sys
 
 import pytest
 
 # Use full imports so we can run this with mpiexec externally
-from schwimmbad.tests import TEST_MPI
 from schwimmbad.tests.test_pools import _function, isclose
-from schwimmbad.mpi import MPIPool, MPI
+from schwimmbad.mpi import MPIPool, MPIAsyncPool
+
 
 def _callback(x):
     pass
 
-@pytest.mark.skip(True, reason="WTF")
+
+@pytest.mark.skip(True, reason="tested outside of standard pytest call")
 def test_mpi():
     pool = MPIPool()
 
@@ -28,7 +30,7 @@ def test_mpi():
     # test map alone
     for tasks in all_tasks:
         results = pool.map(_function, tasks)
-        for r1,r2 in zip(results, [_function(x) for x in tasks]):
+        for r1, r2 in zip(results, [_function(x) for x in tasks]):
             assert isclose(r1, r2)
 
         assert len(results) == len(tasks)
@@ -36,12 +38,40 @@ def test_mpi():
     # test map with callback
     for tasks in all_tasks:
         results = pool.map(_function, tasks, callback=_callback)
-        for r1,r2 in zip(results, [_function(x) for x in tasks]):
+        for r1, r2 in zip(results, [_function(x) for x in tasks]):
             assert isclose(r1, r2)
 
         assert len(results) == len(tasks)
 
     pool.close()
 
+
+@pytest.mark.skip(True, reason="tested outside of standard pytest call")
+def test_mpi_async():
+    all_tasks = [[random.random() for i in range(1000)]]
+
+    with MPIAsyncPool() as pool:
+
+        # test map alone
+        for tasks in all_tasks:
+            results = pool.map(_function, tasks)
+            for r1, r2 in zip(results, [_function(x) for x in tasks]):
+                assert isclose(r1, r2)
+
+            assert len([r for r in pool.map(_function, tasks)]) == len(tasks)
+
+        # test map with callback
+        for tasks in all_tasks:
+            results = pool.map(_function, tasks, callback=_callback)
+            for r1, r2 in zip(results, [_function(x) for x in tasks]):
+                assert isclose(r1, r2)
+
+            assert len([r for r in pool.map(_function, tasks)]) == len(tasks)
+
+
 if __name__ == '__main__':
-    test_mpi()
+    if 'SCHWIMMBAD_TEST_MPI' in os.environ:
+        test_mpi()
+
+    if 'SCHWIMMBAD_TEST_MPIASYNC' in os.environ:
+        test_mpi_async()


### PR DESCRIPTION
This implements a subclass of [mpi4py.futures.MPIPoolExecutor](https://mpi4py.readthedocs.io/en/stable/mpi4py.futures.html) that supports specifying a callback function, and has a consistent API with the other pool classes in schwimmbad.

@edwardreed81 this might solve #18