### PR TITLE
Add some support for creating batches out of task lists

### DIFF
--- a/schwimmbad/pool.py
+++ b/schwimmbad/pool.py
@@ -1,6 +1,9 @@
 # Standard library
 import abc
 
+# This package
+from .utils import batch_tasks
+
 __all__ = ['BasePool']
 
 
@@ -32,6 +35,10 @@ class BasePool(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def map(self, *args, **kwargs):
         return
+
+    def batched_map(self, worker, tasks, *args, **kwargs):
+        batches = batch_tasks(n_batches=self.size, arr=tasks)
+        return self.map(worker, batches, *args, **kwargs)
 
     def close(self):
         pass

--- a/schwimmbad/tests/test_mpi.py
+++ b/schwimmbad/tests/test_mpi.py
@@ -10,7 +10,7 @@ import pytest
 
 # Use full imports so we can run this with mpiexec externally
 from schwimmbad.tests import TEST_MPI  # noqa
-from schwimmbad.tests.test_pools import _function, isclose
+from schwimmbad.tests.test_pools import _function, _batch_function, isclose
 from schwimmbad.mpi import MPIPool, MPI  # noqa
 
 
@@ -38,6 +38,11 @@ def test_mpi():
                 assert isclose(r1, r2)
 
             assert len(results) == len(tasks)
+
+        # test batched map
+        results = pool.batched_map(_batch_function, tasks)
+        for r in results:
+            assert all([isclose(x, 42.01) for x in r])
 
 
 if __name__ == '__main__':

--- a/schwimmbad/tests/test_pools.py
+++ b/schwimmbad/tests/test_pools.py
@@ -1,5 +1,4 @@
 # Standard library
-from __future__ import division, print_function, absolute_import, unicode_literals
 import time
 import random
 
@@ -8,8 +7,10 @@ from ..serial import SerialPool
 from ..multiprocessing import MultiPool
 from ..jl import JoblibPool
 
+
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
     return abs(a-b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
+
 
 def _function(x):
     """
@@ -17,6 +18,18 @@ def _function(x):
     """
     time.sleep(random.random()*4E-4 + 1E-4)
     return 42.01
+
+
+def _batch_function(batch):
+    """
+    Wastes a random amount of time, returns the number 42.01 - accepts a batch
+    of tasks instead of a single task
+    """
+    results = []
+    for x in batch:
+        time.sleep(random.random()*4E-4 + 1E-4)
+        results.append(42.01)
+    return results
 
 
 class PoolTestBase(object):

--- a/schwimmbad/tests/test_utils.py
+++ b/schwimmbad/tests/test_utils.py
@@ -27,6 +27,10 @@ def test_batch_tasks():
     tasks = batch_tasks(10, arr=arr, args=(99,))
     assert len(tasks) == 10
 
+    arr = np.arange(100)
+    tasks = batch_tasks(10, arr=arr, include_idx=False)
+    assert np.all(tasks[0] == np.arange(10))
+
     tasks = batch_tasks(100, n_tasks=5)
     assert len(tasks) == 5
 

--- a/schwimmbad/tests/test_utils.py
+++ b/schwimmbad/tests/test_utils.py
@@ -1,0 +1,40 @@
+try:
+    import numpy as np
+    has_numpy = True
+except ImportError:
+    has_numpy = False
+
+import pytest
+from ..utils import batch_tasks
+
+
+@pytest.mark.skipif(not has_numpy,
+                    reason="Numpy is required to run this test")
+def test_batch_tasks():
+    tasks = batch_tasks(10, n_tasks=100)
+    assert len(tasks) == 10
+    assert tasks[0] == (0, 10)
+
+    tasks = batch_tasks(10, n_tasks=100, args=(10,))
+    assert len(tasks) == 10
+    assert tasks[0] == ((0, 10), 10)
+
+    tasks = batch_tasks(10, n_tasks=101, args=(99,))
+    assert len(tasks) == 10
+
+    # With array specified
+    arr = np.random.random(size=123)
+    tasks = batch_tasks(10, arr=arr, args=(99,))
+    assert len(tasks) == 10
+
+    tasks = batch_tasks(100, n_tasks=5)
+    assert len(tasks) == 5
+
+    with pytest.raises(ValueError):
+        batch_tasks(0, n_tasks=100)
+
+    with pytest.raises(ValueError):
+        batch_tasks(100, n_tasks=0)
+
+    with pytest.raises(ValueError):
+        batch_tasks(100, n_tasks=100, arr=arr[:100])

--- a/schwimmbad/utils.py
+++ b/schwimmbad/utils.py
@@ -1,0 +1,71 @@
+__all__ = ['batch_tasks']
+
+
+def batch_tasks(n_batches, n_tasks=None, arr=None, args=None, start_idx=0):
+    """Split tasks into some number of batches to send out to workers.
+
+    By default, returns index ranges that split the number of tasks into the
+    specified number of batches. If an array is passed in via ``arr``, it splits
+    the array directly along ``axis=0`` into the specified number of batches.
+
+    Parameters
+    ----------
+    n_batches : int
+        The number of batches to split the tasks into. Often, you may want to do
+        ``n_batches=pool.size`` for equal sharing amongst MPI workers.
+    n_tasks : int (optional)
+        The total number of tasks to divide.
+    arr : iterable (optional)
+        Instead of returning indices that specify the batches, you can also
+        directly split an array into batches.
+    args : iterable (optional)
+        Other arguments to add to each task.
+    start_idx : int (optional)
+        What index in the tasks to start from?
+    """
+    if args is None:
+        args = tuple()
+    args = tuple(args)
+
+    if ((n_tasks is None and arr is None) or
+            (n_tasks is not None and arr is not None)):
+        raise ValueError("you must pass one of n_tasks or arr (not both)")
+    elif n_tasks is None:
+        n_tasks = len(arr)
+
+    if n_batches <= 0 or n_tasks <= 0:
+        raise ValueError("n_batches and n_tasks must be > 0")
+
+    if n_batches > n_tasks:
+        # TODO: add a warning?
+        n_batches = n_tasks
+
+    # Chunk by the number of batches, often the pool size
+    base_batch_size = n_tasks // n_batches
+    rmdr = n_tasks % n_batches
+
+    i1 = start_idx
+    indices = []
+    for i in range(n_batches):
+        i2 = i1 + base_batch_size
+        if i < rmdr:
+            i2 += 1
+
+        indices.append((i1, i2))
+        i1 = i2
+
+    # Add args, possible slice input array:
+    tasks = []
+    for idx in indices:
+        extra = list()
+        if arr is not None:
+            extra.append(arr[idx[0]:idx[1]])
+        if args:
+            extra.extend(args)
+
+        if extra:
+            tasks.append(tuple([idx] + extra))
+        else:
+            tasks.append(idx)
+
+    return tasks

--- a/schwimmbad/utils.py
+++ b/schwimmbad/utils.py
@@ -1,7 +1,8 @@
 __all__ = ['batch_tasks']
 
 
-def batch_tasks(n_batches, n_tasks=None, arr=None, args=None, start_idx=0):
+def batch_tasks(n_batches, n_tasks=None, arr=None, args=None, start_idx=0,
+                include_idx=True):
     """Split tasks into some number of batches to send out to workers.
 
     By default, returns index ranges that split the number of tasks into the
@@ -22,6 +23,9 @@ def batch_tasks(n_batches, n_tasks=None, arr=None, args=None, start_idx=0):
         Other arguments to add to each task.
     start_idx : int (optional)
         What index in the tasks to start from?
+    include_idx : bool (optional)
+        If passing an array in, this determines whether to include the indices
+        of each batch with each task.
     """
     if args is None:
         args = tuple()
@@ -57,14 +61,20 @@ def batch_tasks(n_batches, n_tasks=None, arr=None, args=None, start_idx=0):
     # Add args, possible slice input array:
     tasks = []
     for idx in indices:
+        if arr is not None and not args and not include_idx:
+            tasks.append(arr[idx[0]:idx[1]])
+            continue
+
         extra = list()
         if arr is not None:
             extra.append(arr[idx[0]:idx[1]])
         if args:
             extra.extend(args)
 
-        if extra:
+        if extra and include_idx:
             tasks.append(tuple([idx] + extra))
+        elif extra and not include_idx:
+            tasks.append(extra)
         else:
             tasks.append(idx)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ test =
     mpi4py
     joblib
     matplotlib
+    numpy
 docs =
     alabaster
     emcee


### PR DESCRIPTION
This adds a utility function `batch_tasks()` that can split up a list/array of tasks (or just split indices to read into an array of tasks), and adds a method `batched_map()` to pool classes that first batches tasks before map'ing the worker out to each process. This can be handy if you are data-transfer-limited (i.e., individual `worker()` calls are very fast) and you have a lot of tasks to run on.