### PR TITLE
add an option to save RAM in the large calculation

### DIFF
--- a/src/schwimmbad/mpi.py
+++ b/src/schwimmbad/mpi.py
@@ -126,7 +126,7 @@ class MPIPool(BasePool):
         if callback is not None:
             callback()
 
-    def map(self, worker, tasks, callback=None):
+    def map(self, worker, tasks, callback=None, tasklistback=True):
         """Evaluate a function or callable on each task in parallel using MPI.
 
         The callable, ``worker``, is called on each element of the ``tasks``
@@ -149,11 +149,14 @@ class MPIPool(BasePool):
             result from each worker run and is executed on the master process.
             This is useful for, e.g., saving results to a file, since the
             callback is only called on the master thread.
+        tasklistback : bool
+            An option to save memory in the parallel calculations.
 
         Returns
         -------
-        results : list
+        results : list 
             A list of results from the output of each ``worker()`` call.
+            If tasklistback = False, return [None] * len(tasklist)
         """
 
         # If not the master just wait for instructions.
@@ -193,7 +196,8 @@ class MPIPool(BasePool):
             callback(result)
 
             workerset.add(worker)
-            resultlist[taskid] = result
+            if tasklistback:
+                resultlist[taskid] = result
             pending -= 1
 
         return resultlist

--- a/src/schwimmbad/mpi.py
+++ b/src/schwimmbad/mpi.py
@@ -126,7 +126,7 @@ class MPIPool(BasePool):
         if callback is not None:
             callback()
 
-    def map(self, worker, tasks, callback=None, tasklistback=True):
+    def map(self, worker, tasks, callback=None, return_results=True):
         """Evaluate a function or callable on each task in parallel using MPI.
 
         The callable, ``worker``, is called on each element of the ``tasks``
@@ -149,14 +149,14 @@ class MPIPool(BasePool):
             result from each worker run and is executed on the master process.
             This is useful for, e.g., saving results to a file, since the
             callback is only called on the master thread.
-        tasklistback : bool
-            An option to save memory in the parallel calculations.
+        return_results : bool, optional
+            An option to disable returning the full result list, which can save memory usage in the parallel calculations when large results are returned.
 
         Returns
         -------
         results : list 
             A list of results from the output of each ``worker()`` call.
-            If tasklistback = False, return [None] * len(tasklist)
+            But if `return_results = False`, this function returns `None`. 
         """
 
         # If not the master just wait for instructions.
@@ -196,11 +196,14 @@ class MPIPool(BasePool):
             callback(result)
 
             workerset.add(worker)
-            if tasklistback:
+            if return_results:
                 resultlist[taskid] = result
             pending -= 1
 
-        return resultlist
+        if return_results:
+            return resultlist
+        else:
+            return None
 
     def close(self):
         """Tell all the workers to quit."""

--- a/src/schwimmbad/mpi.py
+++ b/src/schwimmbad/mpi.py
@@ -150,13 +150,16 @@ class MPIPool(BasePool):
             This is useful for, e.g., saving results to a file, since the
             callback is only called on the master thread.
         return_results : bool, optional
-            An option to disable returning the full result list, which can save memory usage in the parallel calculations when large results are returned.
+            An option to disable returning the full result list, which can save memory
+            usage in the parallel calculations when large results are returned. This is
+            useful if you need to call a callback function on each result and don't need
+            to store the results in memory.
 
         Returns
         -------
-        results : list 
+        results : list
             A list of results from the output of each ``worker()`` call.
-            But if `return_results = False`, this function returns `None`. 
+            But if `return_results = False`, this function returns `None`.
         """
 
         # If not the master just wait for instructions.
@@ -202,8 +205,7 @@ class MPIPool(BasePool):
 
         if return_results:
             return resultlist
-        else:
-            return None
+        return None
 
     def close(self):
         """Tell all the workers to quit."""


### PR DESCRIPTION
In many times, we need MPI to do massive calculations, therefore, there are LARGE `result` in the `resultlist`, leading to the memory leak. I add an option to disable record the `resultlist`.