### PR TITLE
Use multiprocess instead of multiprocessing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/README.md
+++ b/README.md
@@ -1,13 +1,9 @@
 # das Schwimmbad
 
-[![image](https://github.com/adrn/schwimmbad/actions/workflows/tests.yml/badge.svg)](https://github.com/adrn/schwimmbad/actions/workflows/tests.yml)
-
+[![image](https://github.com/adrn/schwimmbad/actions/workflows/ci.yml/badge.svg)](https://github.com/adrn/schwimmbad/actions/workflows/ci.yml)
 [![image](http://img.shields.io/pypi/v/schwimmbad.svg?style=flat)](https://pypi.python.org/pypi/schwimmbad/)
-
 [![image](http://img.shields.io/badge/license-MIT-blue.svg?style=flat)](https://github.com/adrn/schwimmbad/blob/master/LICENSE)
-
 [![image](https://zenodo.org/badge/DOI/10.5281/zenodo.885577.svg)](https://zenodo.org/record/885577#.Wa9WVBZSy2w)
-
 [![image](http://joss.theoj.org/papers/10.21105/joss.00357/status.svg)](http://dx.doi.org/10.21105/joss.00357)
 
 `schwimmbad` provides a uniform interface to parallel processing pools and enables

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ test = [
   "pytest-astropy",
 ]
 docs = [
-  "schwimmbad[all]",
   "sphinx>=7.0",
   "sphinx_copybutton",
   "sphinx_autodoc_typehints",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,12 @@ readme = "README.md"
 license.file = "LICENSE"
 requires-python = ">=3.9"
 dynamic = ["version"]
-dependencies = ["dill"]
+dependencies = ["dill", "multiprocess"]
 
 [project.optional-dependencies]
 all = [
   "joblib",
-  "mpi4py",
+  "mpi4py"
 ]
 test = [
   "schwimmbad[all]",

--- a/src/schwimmbad/multiprocessing.py
+++ b/src/schwimmbad/multiprocessing.py
@@ -1,8 +1,9 @@
 # type: ignore
 import functools
-import multiprocessing
 import signal
-from multiprocessing.pool import Pool
+
+import multiprocess
+from multiprocess.pool import Pool
 
 __all__ = ["MultiPool"]
 
@@ -30,10 +31,12 @@ class CallbackWrapper:
 
 class MultiPool(Pool):
     """
-    A modified version of :class:`multiprocessing.pool.Pool` that has better
+    A modified version of :class:`multiprocess.pool.Pool` that has better
     behavior with regard to ``KeyboardInterrupts`` in the :func:`map` method.
 
-    (Original author: `Peter K. G. Williams <peter@newton.cx>`_)
+    NOTE: This is no longer built off of the standard library
+    :class:`multiprocessing.pool.Pool` -- this uses the version from `multiprocess`,
+    which uses `dill` to pickle objects instead of the standard library `pickle`.
 
     Parameters
     ----------
@@ -46,8 +49,7 @@ class MultiPool(Pool):
         Arguments for ``initializer``; it will be called as
         ``initializer(*initargs)``.
     kwargs:
-        Extra arguments passed to the :class:`multiprocessing.pool.Pool`
-        superclass.
+        Extra arguments passed to the :class:`multiprocess.pool.Pool` superclass.
 
     """
 
@@ -104,7 +106,7 @@ class MultiPool(Pool):
             try:
                 return r.get(self.wait_timeout)
 
-            except multiprocessing.TimeoutError:
+            except multiprocess.TimeoutError:
                 pass
 
             except KeyboardInterrupt:


### PR DESCRIPTION
The multiprocess package is a fork of the Python standard library multiprocessing, but it uses `dill` to handle object serialization instead of `pickle`. `dill` is much more flexible, so I think it is better to just adopt this pool instead. The `MultiPool` is a very light wrapper around `multiprocessing.pool.Pool` anyways, so if users for some reason prefer the std lib version, they can just use that directly...