### PR TITLE
use send rather than ssend to avoid lockup

### DIFF
--- a/src/schwimmbad/mpi.py
+++ b/src/schwimmbad/mpi.py
@@ -121,7 +121,7 @@ class MPIPool(BasePool):
 
             result = func(arg)
 
-            self.comm.ssend(result, self.master, status.tag)
+            self.comm.send(result, self.master, status.tag)
 
         if callback is not None:
             callback()


### PR DESCRIPTION
Hi,

I'm using Ubuntu 20.04, with the OS openmpi package, mpi4py 3.1.5, and schwimmbad 0.3.2.  This is on the "symmetry" cluster at Perimeter Institute.

The behavior I'm seeing is that when creating an MPIPool(), I see each worker getting one task, it finishes the task and sends the result back, and the boss receives the result, but the workers never proceed to the next task.

Via some sophisticated printf debugging, I found that the workers were never returning from the `self.comm.ssend()` call.  My wise colleague suggested changing that to `self.comm.send()`, and then it works perfectly!

I don't _think_ you need any of the synchronization implied by `ssend`, so this should be fine?

My system details:

$ mpiexec --version
mpiexec (OpenRTE) 4.0.3
$ ls -l $(which mpiexec)
lrwxrwxrwx 1 root root 25 Aug 15  2023 /usr/bin/mpiexec -> /etc/alternatives/mpiexec
$ ls -l /etc/alternatives/mpiexec
lrwxrwxrwx 1 root root 24 Aug 15  2023 /etc/alternatives/mpiexec -> /usr/bin/mpiexec.openmpi

